### PR TITLE
Fix connector registration on service provider

### DIFF
--- a/src/MnsServiceProvider.php
+++ b/src/MnsServiceProvider.php
@@ -7,11 +7,9 @@ use Illuminate\Support\ServiceProvider;
 class MnsServiceProvider extends ServiceProvider
 {
     /**
-     * Register any application services.
-     *
-     * @return void
+     * Bootstrap any application services.
      */
-    public function register()
+    public function boot(): void
     {
         $this->registerConnector();
     }


### PR DESCRIPTION
We could ensure all other service providers have been registered when the `boot` method is being called. Register the MNS connector in `register` method, the Queue manager could not be resolved because the service provider might not be loaded yet.