### PR TITLE
Fix PHPStan errors and throws exception when result was failed

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -8,3 +8,8 @@ parameters:
         - src
 
     treatPhpDocTypesAsCertain: false
+
+    ignoreErrors:
+        -
+            message: '#constructor expects string, mixed given.$#'
+            path: src/MnsConnector.php

--- a/src/MnsConnector.php
+++ b/src/MnsConnector.php
@@ -11,6 +11,7 @@ class MnsConnector implements ConnectorInterface
     /**
      * Establish a queue connection.
      *
+     * @param  array<mixed>  $config
      * @return \Illuminate\Contracts\Queue\Queue
      */
     public function connect(array $config)

--- a/src/MnsJob.php
+++ b/src/MnsJob.php
@@ -38,7 +38,7 @@ class MnsJob extends Job implements JobContract
         parent::release($delay);
 
         $this->mns->changeMessageVisibility(
-            $this->queue, $this->job->receiptHandle(), $delay
+            $this->queue, (string) $this->job->receiptHandle(), $delay
         );
     }
 
@@ -51,7 +51,7 @@ class MnsJob extends Job implements JobContract
     {
         parent::delete();
 
-        $this->mns->deleteMessage($this->queue, $this->job->receiptHandle());
+        $this->mns->deleteMessage($this->queue, (string) $this->job->receiptHandle());
     }
 
     /**
@@ -71,7 +71,7 @@ class MnsJob extends Job implements JobContract
      */
     public function getJobId()
     {
-        return $this->job->messageId();
+        return (string) $this->job->messageId();
     }
 
     /**
@@ -81,7 +81,7 @@ class MnsJob extends Job implements JobContract
      */
     public function getRawBody()
     {
-        return $this->job->messageBody();
+        return (string) $this->job->messageBody();
     }
 
     /**

--- a/src/MnsJob.php
+++ b/src/MnsJob.php
@@ -37,9 +37,15 @@ class MnsJob extends Job implements JobContract
     {
         parent::release($delay);
 
-        $this->mns->changeMessageVisibility(
+        $result = $this->mns->changeMessageVisibility(
             $this->queue, (string) $this->job->receiptHandle(), $delay
         );
+
+        if ($result->failed()) {
+            throw new MnsQueueException(sprintf('Release the job with error [%s] %s',
+                $result->errorCode(), $result->errorMessage()
+            ));
+        }
     }
 
     /**
@@ -51,7 +57,13 @@ class MnsJob extends Job implements JobContract
     {
         parent::delete();
 
-        $this->mns->deleteMessage($this->queue, (string) $this->job->receiptHandle());
+        $result = $this->mns->deleteMessage($this->queue, (string) $this->job->receiptHandle());
+
+        if ($result->failed()) {
+            throw new MnsQueueException(sprintf('Delete the job with error [%s] %s',
+                $result->errorCode(), $result->errorMessage()
+            ));
+        }
     }
 
     /**

--- a/src/MnsQueue.php
+++ b/src/MnsQueue.php
@@ -50,9 +50,11 @@ class MnsQueue extends Queue implements QueueContract
      */
     public function push($job, $data = '', $queue = null)
     {
+        $queue = $this->getQueue($queue);
+
         return $this->enqueueUsing(
             $job,
-            $this->createPayload($job, $queue ?: $this->default, $data),
+            $this->createPayload($job, $queue, $data),
             $queue,
             null,
             fn ($payload, $queue) => $this->pushRaw($payload, $queue)
@@ -84,9 +86,11 @@ class MnsQueue extends Queue implements QueueContract
      */
     public function later($delay, $job, $data = '', $queue = null)
     {
+        $queue = $this->getQueue($queue);
+
         return $this->enqueueUsing(
             $job,
-            $this->createPayload($job, $queue ?: $this->default, $data),
+            $this->createPayload($job, $queue, $data),
             $queue,
             $delay,
             fn ($payload, $queue, $delay) => $this->pushRaw($payload, $queue, [

--- a/src/MnsQueue.php
+++ b/src/MnsQueue.php
@@ -27,11 +27,17 @@ class MnsQueue extends Queue implements QueueContract
      */
     public function size($queue = null)
     {
-        $attributes = $this->mns->getQueueAttributes($this->getQueue($queue));
+        $result = $this->mns->getQueueAttributes($this->getQueue($queue));
 
-        return $attributes->activeMessages()
-            + $attributes->inactiveMessages()
-            + $attributes->delayMessages();
+        if ($result->failed()) {
+            throw new MnsQueueException(sprintf('Get the size of the queue with error [%s] %s.',
+                $result->errorCode(), $result->errorMessage()
+            ));
+        }
+
+        return (int) $result->activeMessages()
+            + (int) $result->inactiveMessages()
+            + (int) $result->delayMessages();
     }
 
     /**

--- a/src/MnsQueue.php
+++ b/src/MnsQueue.php
@@ -143,6 +143,10 @@ class MnsQueue extends Queue implements QueueContract
      */
     public function getQueue(string $queue = null): string
     {
-        return $queue ?: $this->default;
+        if (is_string($queue)) {
+            return $queue;
+        }
+
+        return $this->default;
     }
 }

--- a/src/MnsQueue.php
+++ b/src/MnsQueue.php
@@ -66,6 +66,7 @@ class MnsQueue extends Queue implements QueueContract
      *
      * @param  string  $payload
      * @param  string|null  $queue
+     * @param  array<mixed>  $options
      * @return mixed
      */
     public function pushRaw($payload, $queue = null, array $options = [])
@@ -102,7 +103,7 @@ class MnsQueue extends Queue implements QueueContract
     /**
      * Push an array of jobs onto the queue.
      *
-     * @param  array  $jobs
+     * @param  array<mixed>  $jobs
      * @param  mixed  $data
      * @param  string|null  $queue
      * @return void

--- a/src/MnsQueue.php
+++ b/src/MnsQueue.php
@@ -111,9 +111,10 @@ class MnsQueue extends Queue implements QueueContract
     public function bulk($jobs, $data = '', $queue = null)
     {
         foreach ((array) $jobs as $job) {
-            if (isset($job->delay)) {
+            if (is_object($job) && isset($job->delay)) {
                 $this->later($job->delay, $job, $data, $queue);
             } else {
+                /** @var object|string $job */
                 $this->push($job, $data, $queue);
             }
         }

--- a/src/MnsQueueException.php
+++ b/src/MnsQueueException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Dew\MnsDriver;
+
+use Exception;
+
+class MnsQueueException extends Exception
+{
+    //
+}

--- a/src/MnsServiceProvider.php
+++ b/src/MnsServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Dew\MnsDriver;
 
+use Illuminate\Queue\QueueManager;
 use Illuminate\Support\ServiceProvider;
 
 class MnsServiceProvider extends ServiceProvider
@@ -19,6 +20,10 @@ class MnsServiceProvider extends ServiceProvider
      */
     protected function registerConnector(): void
     {
-        $this->app->make('queue')->addConnector('mns', fn () => new MnsConnector);
+        $manager = $this->app->make('queue');
+
+        if ($manager instanceof QueueManager) {
+            $manager->addConnector('mns', fn () => new MnsConnector);
+        }
     }
 }


### PR DESCRIPTION
Sorry to put two features in one PR.

When a queue or job request fails, there is no more silence, and `MnsQueueException` should be thrown.