### PR TITLE
Supports clear queue

### DIFF
--- a/src/MnsQueue.php
+++ b/src/MnsQueue.php
@@ -194,7 +194,10 @@ class MnsQueue extends Queue implements ClearableQueue, QueueContract
      */
     protected function retrieveMessages(string $queue): BatchReceiveMessageResult|bool
     {
-        $result = $this->mns->batchReceiveMessage($queue, ['numOfMessages' => '16', 'waitseconds' => '30']);
+        $result = $this->mns->batchReceiveMessage($queue, [
+            'numOfMessages' => '16',  // max messages we could get at a time
+            'waitseconds' => '30',    // max timeout
+        ]);
 
         if ($result->failed() && $result->errorCode() === 'MessageNotExist') {
             return false;


### PR DESCRIPTION
The MNS SDK can't purge the queue in one command. We implemented the clear feature by receiving the messages as many as possible in the queue at a time and deleting those altogether until we couldn't get any new messages. The returning counter is the actual deleted messages.