### PR TITLE
Supports customize HTTP client

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "php": "^8.0",
         "illuminate/contracts": "^10.0",
         "illuminate/queue": "^10.0",
-        "dew-serverless/mns": "^1.0"
+        "dew-serverless/mns": "^1.1"
     },
     "require-dev": {
         "pestphp/pest": "^2.23",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -8,8 +8,3 @@ parameters:
         - src
 
     treatPhpDocTypesAsCertain: false
-
-    ignoreErrors:
-        -
-            message: '#constructor expects string, mixed given.$#'
-            path: src/MnsConnector.php

--- a/src/MnsConnector.php
+++ b/src/MnsConnector.php
@@ -18,6 +18,22 @@ class MnsConnector implements ConnectorInterface
     {
         $mns = new MnsClient($config['endpoint'], $config['key'], $config['secret']);
 
+        $mns->configure($this->withDefaultConfiguration($config['http'] ?? []));
+
         return new MnsQueue(new Queue($mns), $config['queue']);
+    }
+
+    /**
+     * Build a configuration with default one.
+     *
+     * @param  array<string, mixed>  $config
+     * @return array<string, mixed>
+     */
+    protected function withDefaultConfiguration(array $config = []): array
+    {
+        // timeout: receiving messages could take up to 30 seconds.
+        return array_merge([
+            'timeout' => 60.0,
+        ], $config);
     }
 }

--- a/src/MnsConnector.php
+++ b/src/MnsConnector.php
@@ -6,6 +6,15 @@ use Dew\Mns\MnsClient;
 use Dew\Mns\Versions\V20150606\Queue;
 use Illuminate\Queue\Connectors\ConnectorInterface;
 
+/**
+ * @phpstan-type Config array{
+ *     endpoint: string,
+ *     key: string,
+ *     secret: string,
+ *     queue: string,
+ *     http?: array<string, mixed>
+ * }
+ */
 class MnsConnector implements ConnectorInterface
 {
     /**
@@ -16,6 +25,7 @@ class MnsConnector implements ConnectorInterface
      */
     public function connect(array $config)
     {
+        /** @var Config $config */
         $mns = new MnsClient($config['endpoint'], $config['key'], $config['secret']);
 
         $mns->configure($this->withDefaultConfiguration($config['http'] ?? []));


### PR DESCRIPTION
The PR gives the ability to pass through HTTP config to the MNS client. The redundant 60-second timeout could help us confidently guarantee the timeout exists no matter if the upstream SDK package changes it.