### PR TITLE
Exposes MNS queue instance

### DIFF
--- a/src/MnsQueue.php
+++ b/src/MnsQueue.php
@@ -247,4 +247,14 @@ class MnsQueue extends Queue implements ClearableQueue, QueueContract
 
         return $this->default;
     }
+
+    /**
+     * The underlying MNS queue.
+     *
+     * @return \Dew\Mns\Versions\V20150606\Queue
+     */
+    public function getMns()
+    {
+        return $this->mns;
+    }
 }


### PR DESCRIPTION
The MNS queue instance pass in the constructor is being protected. We could not resolve the underlying queue without a getter method once we lost the reference.